### PR TITLE
Improve student activity registration system

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ fastapi
 uvicorn
 httpx
 watchfiles
+pytest

--- a/src/app.py
+++ b/src/app.py
@@ -107,3 +107,22 @@ def signup_for_activity(activity_name: str, email: str):
     # Add student
     activity["participants"].append(email)
     return {"message": f"Signed up {email} for {activity_name}"}
+
+
+@app.delete("/activities/{activity_name}/unregister")
+def unregister_from_activity(activity_name: str, email: str):
+    """Unregister a student from an activity"""
+    # Validate activity exists
+    if activity_name not in activities:
+        raise HTTPException(status_code=404, detail="Activity not found")
+
+    # Get the specific activity
+    activity = activities[activity_name]
+
+    # Validate student is signed up
+    if email not in activity["participants"]:
+        raise HTTPException(status_code=400, detail="Student is not signed up for this activity")
+
+    # Remove student
+    activity["participants"].remove(email)
+    return {"message": f"Unregistered {email} from {activity_name}"}

--- a/src/app.py
+++ b/src/app.py
@@ -5,6 +5,8 @@ A super simple FastAPI application that allows students to view and sign up
 for extracurricular activities at Mergington High School.
 """
 
+import email
+
 from fastapi import FastAPI, HTTPException
 from fastapi.staticfiles import StaticFiles
 from fastapi.responses import RedirectResponse
@@ -38,6 +40,42 @@ activities = {
         "schedule": "Mondays, Wednesdays, Fridays, 2:00 PM - 3:00 PM",
         "max_participants": 30,
         "participants": ["john@mergington.edu", "olivia@mergington.edu"]
+    },
+    "Soccer Team": {
+        "description": "Team practices and inter-school soccer matches",
+        "schedule": "Mondays and Wednesdays, 4:00 PM - 5:30 PM",
+        "max_participants": 22,
+        "participants": ["liam@mergington.edu", "ava@mergington.edu"]
+    },
+    "Basketball Club": {
+        "description": "Skill drills, scrimmages, and league games",
+        "schedule": "Tuesdays and Fridays, 4:00 PM - 5:30 PM",
+        "max_participants": 15,
+        "participants": ["noah@mergington.edu", "isabella@mergington.edu"]
+    },
+    "Art Studio": {
+        "description": "Explore drawing, painting, and mixed media projects",
+        "schedule": "Wednesdays, 3:30 PM - 5:00 PM",
+        "max_participants": 18,
+        "participants": ["mia@mergington.edu", "charlotte@mergington.edu"]
+    },
+    "Drama Club": {
+        "description": "Acting workshops and school theater productions",
+        "schedule": "Thursdays, 3:30 PM - 5:30 PM",
+        "max_participants": 25,
+        "participants": ["amelia@mergington.edu", "elijah@mergington.edu"]
+    },
+    "Debate Team": {
+        "description": "Develop public speaking and critical thinking through debate",
+        "schedule": "Mondays, 3:30 PM - 5:00 PM",
+        "max_participants": 16,
+        "participants": ["james@mergington.edu", "harper@mergington.edu"]
+    },
+    "Math Olympiad": {
+        "description": "Advanced problem-solving and competition preparation",
+        "schedule": "Fridays, 3:30 PM - 5:00 PM",
+        "max_participants": 14,
+        "participants": ["lucas@mergington.edu", "evelyn@mergington.edu"]
     }
 }
 
@@ -61,6 +99,10 @@ def signup_for_activity(activity_name: str, email: str):
 
     # Get the specific activity
     activity = activities[activity_name]
+
+    # Validate student is not already signed up
+    if email in activity["participants"]:
+        raise HTTPException(status_code=400, detail="Student is already signed up")
 
     # Add student
     activity["participants"].append(email)

--- a/src/static/app.js
+++ b/src/static/app.js
@@ -19,12 +19,45 @@ document.addEventListener("DOMContentLoaded", () => {
         activityCard.className = "activity-card";
 
         const spotsLeft = details.max_participants - details.participants.length;
+        
+        // Build participants list HTML
+        let participantsHTML = '';
+        if (details.participants && details.participants.length > 0) {
+          const participantItems = details.participants
+            .map(email => `
+              <li>
+                <span class="participant-email">${email}</span>
+                <button class="delete-participant" data-activity="${name}" data-email="${email}" title="Remove participant">
+                  <svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+                    <path d="M12 4L4 12M4 4L12 12" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+                  </svg>
+                </button>
+              </li>
+            `)
+            .join('');
+          participantsHTML = `
+            <div class="participants-section">
+              <p><strong>Current Participants:</strong></p>
+              <ul class="participants-list">
+                ${participantItems}
+              </ul>
+            </div>
+          `;
+        } else {
+          participantsHTML = `
+            <div class="participants-section">
+              <p><strong>Current Participants:</strong></p>
+              <p class="no-participants">No participants yet. Be the first to sign up!</p>
+            </div>
+          `;
+        }
 
         activityCard.innerHTML = `
           <h4>${name}</h4>
           <p>${details.description}</p>
           <p><strong>Schedule:</strong> ${details.schedule}</p>
           <p><strong>Availability:</strong> ${spotsLeft} spots left</p>
+          ${participantsHTML}
         `;
 
         activitiesList.appendChild(activityCard);
@@ -62,6 +95,9 @@ document.addEventListener("DOMContentLoaded", () => {
         messageDiv.textContent = result.message;
         messageDiv.className = "success";
         signupForm.reset();
+        
+        // Refresh activities list to show the new participant
+        fetchActivities();
       } else {
         messageDiv.textContent = result.detail || "An error occurred";
         messageDiv.className = "error";
@@ -78,6 +114,53 @@ document.addEventListener("DOMContentLoaded", () => {
       messageDiv.className = "error";
       messageDiv.classList.remove("hidden");
       console.error("Error signing up:", error);
+    }
+  });
+
+  // Handle delete participant
+  activitiesList.addEventListener("click", async (event) => {
+    const deleteButton = event.target.closest(".delete-participant");
+    if (!deleteButton) return;
+
+    const activity = deleteButton.dataset.activity;
+    const email = deleteButton.dataset.email;
+
+    if (!confirm(`Are you sure you want to remove ${email} from ${activity}?`)) {
+      return;
+    }
+
+    try {
+      const response = await fetch(
+        `/activities/${encodeURIComponent(activity)}/unregister?email=${encodeURIComponent(email)}`,
+        {
+          method: "DELETE",
+        }
+      );
+
+      const result = await response.json();
+
+      if (response.ok) {
+        messageDiv.textContent = result.message;
+        messageDiv.className = "success";
+        messageDiv.classList.remove("hidden");
+
+        // Refresh activities list
+        fetchActivities();
+
+        // Hide message after 5 seconds
+        setTimeout(() => {
+          messageDiv.classList.add("hidden");
+        }, 5000);
+      } else {
+        messageDiv.textContent = result.detail || "Failed to remove participant";
+        messageDiv.className = "error";
+        messageDiv.classList.remove("hidden");
+      }
+    } catch (error) {
+      messageDiv.textContent = "Failed to remove participant. Please try again.";
+      messageDiv.className = "error";
+      messageDiv.classList.remove("hidden");
+      console.error("Error removing participant:", error);
     }
   });
 

--- a/src/static/styles.css
+++ b/src/static/styles.css
@@ -74,6 +74,77 @@ section h3 {
   margin-bottom: 8px;
 }
 
+.participants-section {
+  margin-top: 15px;
+  padding-top: 12px;
+  border-top: 1px dashed #ddd;
+  background-color: #f0f4ff;
+  padding: 12px;
+  border-radius: 4px;
+}
+
+.participants-section p strong {
+  color: #1a237e;
+}
+
+.participants-list {
+  margin-top: 8px;
+  margin-left: 0;
+  padding-left: 0;
+  list-style-type: none;
+  color: #555;
+}
+
+.participants-list li {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 6px;
+  padding: 6px 8px;
+  font-size: 14px;
+  line-height: 1.4;
+  background-color: white;
+  border-radius: 4px;
+  transition: background-color 0.2s;
+}
+
+.participants-list li:hover {
+  background-color: #f5f5f5;
+}
+
+.participant-email {
+  flex: 1;
+}
+
+.delete-participant {
+  background: none;
+  border: none;
+  padding: 4px;
+  cursor: pointer;
+  color: #c62828;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 3px;
+  transition: all 0.2s;
+  margin-left: 8px;
+}
+
+.delete-participant:hover {
+  background-color: #ffebee;
+  transform: scale(1.1);
+}
+
+.delete-participant svg {
+  display: block;
+}
+
+.no-participants {
+  font-style: italic;
+  color: #888;
+  margin-top: 5px;
+}
+
 .form-group {
   margin-bottom: 15px;
 }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,21 @@
+from copy import deepcopy
+
+import pytest
+from fastapi.testclient import TestClient
+
+import src.app as app_module
+
+
+@pytest.fixture
+def client():
+    return TestClient(app_module.app)
+
+
+@pytest.fixture(autouse=True)
+def reset_activities_state():
+    baseline = deepcopy(app_module.activities)
+
+    yield
+
+    app_module.activities.clear()
+    app_module.activities.update(deepcopy(baseline))

--- a/tests/test_activities_list.py
+++ b/tests/test_activities_list.py
@@ -1,0 +1,43 @@
+def test_get_activities_returns_expected_payload(client):
+    # Arrange
+    expected_keys = {
+        "Chess Club",
+        "Programming Class",
+        "Gym Class",
+        "Soccer Team",
+        "Basketball Club",
+        "Art Studio",
+        "Drama Club",
+        "Debate Team",
+        "Math Olympiad",
+    }
+
+    # Act
+    response = client.get("/activities")
+    payload = response.json()
+
+    # Assert
+    assert response.status_code == 200
+    assert set(payload.keys()) == expected_keys
+
+    for activity_data in payload.values():
+        assert "description" in activity_data
+        assert isinstance(activity_data["description"], str)
+        assert "schedule" in activity_data
+        assert isinstance(activity_data["schedule"], str)
+        assert "max_participants" in activity_data
+        assert isinstance(activity_data["max_participants"], int)
+        assert "participants" in activity_data
+        assert isinstance(activity_data["participants"], list)
+
+
+def test_root_redirects_to_static_index(client):
+    # Arrange
+    route = "/"
+
+    # Act
+    response = client.get(route, follow_redirects=False)
+
+    # Assert
+    assert response.status_code == 307
+    assert response.headers["location"] == "/static/index.html"

--- a/tests/test_signup_flow.py
+++ b/tests/test_signup_flow.py
@@ -1,0 +1,116 @@
+def test_signup_adds_student_to_participants(client):
+    # Arrange
+    activity_name = "Chess Club"
+    email = "new.student@mergington.edu"
+
+    # Act
+    response = client.post(f"/activities/{activity_name}/signup", params={"email": email})
+    activities_response = client.get("/activities")
+    participants = activities_response.json()[activity_name]["participants"]
+
+    # Assert
+    assert response.status_code == 200
+    assert response.json() == {"message": f"Signed up {email} for {activity_name}"}
+    assert email in participants
+
+
+def test_signup_unknown_activity_returns_404(client):
+    # Arrange
+    activity_name = "Unknown Club"
+    email = "student@mergington.edu"
+
+    # Act
+    response = client.post(f"/activities/{activity_name}/signup", params={"email": email})
+
+    # Assert
+    assert response.status_code == 404
+    assert response.json()["detail"] == "Activity not found"
+
+
+def test_signup_duplicate_email_returns_400(client):
+    # Arrange
+    activity_name = "Chess Club"
+    existing_email = "michael@mergington.edu"
+
+    # Act
+    response = client.post(
+        f"/activities/{activity_name}/signup",
+        params={"email": existing_email},
+    )
+
+    # Assert
+    assert response.status_code == 400
+    assert response.json()["detail"] == "Student is already signed up"
+
+
+def test_unregister_removes_student_from_participants(client):
+    # Arrange
+    activity_name = "Programming Class"
+    email = "emma@mergington.edu"
+
+    # Act
+    response = client.delete(f"/activities/{activity_name}/unregister", params={"email": email})
+    activities_response = client.get("/activities")
+    participants = activities_response.json()[activity_name]["participants"]
+
+    # Assert
+    assert response.status_code == 200
+    assert response.json() == {"message": f"Unregistered {email} from {activity_name}"}
+    assert email not in participants
+
+
+def test_unregister_unknown_activity_returns_404(client):
+    # Arrange
+    activity_name = "Unknown Club"
+    email = "student@mergington.edu"
+
+    # Act
+    response = client.delete(
+        f"/activities/{activity_name}/unregister",
+        params={"email": email},
+    )
+
+    # Assert
+    assert response.status_code == 404
+    assert response.json()["detail"] == "Activity not found"
+
+
+def test_unregister_missing_student_returns_400(client):
+    # Arrange
+    activity_name = "Soccer Team"
+    email = "not.registered@mergington.edu"
+
+    # Act
+    response = client.delete(
+        f"/activities/{activity_name}/unregister",
+        params={"email": email},
+    )
+
+    # Assert
+    assert response.status_code == 400
+    assert response.json()["detail"] == "Student is not signed up for this activity"
+
+
+def test_signup_then_unregister_updates_state_in_sequence(client):
+    # Arrange
+    activity_name = "Debate Team"
+    email = "sequence.student@mergington.edu"
+
+    # Act
+    signup_response = client.post(
+        f"/activities/{activity_name}/signup",
+        params={"email": email},
+    )
+    after_signup = client.get("/activities").json()[activity_name]["participants"]
+
+    unregister_response = client.delete(
+        f"/activities/{activity_name}/unregister",
+        params={"email": email},
+    )
+    after_unregister = client.get("/activities").json()[activity_name]["participants"]
+
+    # Assert
+    assert signup_response.status_code == 200
+    assert email in after_signup
+    assert unregister_response.status_code == 200
+    assert email not in after_unregister


### PR DESCRIPTION
This pull request adds several new features and improvements to the extracurricular activities app, focusing on participant management for activities. The backend now supports unregistering students from activities, and the frontend provides a UI for viewing and removing participants. Comprehensive tests have also been added to ensure the correctness of the signup and unregister flows.

**Backend enhancements:**

* Added a new API endpoint (`/activities/{activity_name}/unregister`) that allows unregistering a student from an activity, with appropriate validation and error handling.
* Expanded the activities data structure to include several new activities such as Soccer Team, Basketball Club, Art Studio, Drama Club, Debate Team, and Math Olympiad, each with their own participants and details.

**Frontend improvements:**

* Updated the UI to display the current list of participants for each activity, including a delete button next to each participant for easy removal.
* Implemented frontend logic to handle participant removal via the new backend endpoint, including confirmation dialogs, success/error messaging, and automatic refresh of the activities list. [[1]](diffhunk://#diff-7146e1c8a61ac4e715182863a67d7a5a3178a73033e8344cd24f1c67787236e3R120-R166) [[2]](diffhunk://#diff-7146e1c8a61ac4e715182863a67d7a5a3178a73033e8344cd24f1c67787236e3R98-R100)

**Styling updates:**

* Added new CSS styles for the participants section and delete buttons to improve the visual presentation and user experience of participant management.

**Testing improvements:**

* Added new test files and fixtures to verify the activities list, signup, and unregister flows, including state reset between tests for isolation. [[1]](diffhunk://#diff-e52e4ddd58b7ef887ab03c04116e676f6280b824ab7469d5d3080e5cba4f2128R1-R21) [[2]](diffhunk://#diff-e536aa8f0bcccfbe5a3b20f5ce4ed209a5e8c36a250ab499cdc8864d3c3164efR1-R43) [[3]](diffhunk://#diff-fd09e8bfaa4fca33392cd77908d8bffd814377c6a3cfe8bd183a1d46834df1deR1-R116)